### PR TITLE
Add pipeline to publish container to Github Container Registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -75,6 +75,7 @@ def ParseArguments() -> argparse.Namespace:
                             action='append',
                             choices={'ac', 'fgl', 'fgl_b', 'humidifier'},
                             help='Device type. Deprecated, now decided based on OEM model.')
+    group_device.add_argument('--temp_type', required=True, action='append', help='Celsius or Fahrenheit')
 
   group_mqtt = parser_run.add_argument_group('MQTT', 'Settings related to the MQTT')
   group_mqtt.add_argument('--mqtt_host', default=None, help='MQTT broker hostname or IP address.')

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -294,7 +294,7 @@ async def discovery(parsed_args):
         'model': config['oem_model'],
         'sw_version': config['sw_version'],
         'dsn': config['dsn'],
-        'temp_type': parsed_args.temp_type or  config['temp_type'],
+        'temp_type': config['temp_type'],
         'mac_address': config['mac'],
         'ip_address': config['lan_ip'],
         'lanip_key': config['lanip_key'],

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -75,7 +75,6 @@ def ParseArguments() -> argparse.Namespace:
                             action='append',
                             choices={'ac', 'fgl', 'fgl_b', 'humidifier'},
                             help='Device type. Deprecated, now decided based on OEM model.')
-  group_device.add_argument('temp_type', help='Celsius or Fahrenheit')
 
   group_mqtt = parser_run.add_argument_group('MQTT', 'Settings related to the MQTT')
   group_mqtt.add_argument('--mqtt_host', default=None, help='MQTT broker hostname or IP address.')
@@ -91,6 +90,7 @@ def ParseArguments() -> argparse.Namespace:
   parser_discovery.add_argument('app', choices=set(SECRET_MAP), help='The app used for the login.')
   parser_discovery.add_argument('user', help='Username for the app login.')
   parser_discovery.add_argument('passwd', help='Password for the app login.')
+  parser_discovery.add_argument('tmptype', help='Celsius or Fahrenheit')
   parser_discovery.add_argument('-d',
                                 '--device',
                                 default=None,
@@ -295,7 +295,7 @@ async def discovery(parsed_args):
         'model': config['oem_model'],
         'sw_version': config['sw_version'],
         'dsn': config['dsn'],
-        'temp_type': parsed_args.temp_type,
+        'temp_type': parsed_args.tmptype,
         'mac_address': config['mac'],
         'ip_address': config['lan_ip'],
         'lanip_key': config['lanip_key'],

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -294,7 +294,7 @@ async def discovery(parsed_args):
         'model': config['oem_model'],
         'sw_version': config['sw_version'],
         'dsn': config['dsn'],
-        'temp_type': config['temp_type'],
+        'temp_type': parsed_args.temp_type or config['temp_type'],
         'mac_address': config['mac'],
         'ip_address': config['lan_ip'],
         'lanip_key': config['lanip_key'],

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -295,7 +295,7 @@ async def discovery(parsed_args):
         'model': config['oem_model'],
         'sw_version': config['sw_version'],
         'dsn': config['dsn'],
-        'temp_type': parsed_args.temp_type or config['temp_type'],
+        'temp_type': parsed_args.temp_type,
         'mac_address': config['mac'],
         'ip_address': config['lan_ip'],
         'lanip_key': config['lanip_key'],

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -75,7 +75,7 @@ def ParseArguments() -> argparse.Namespace:
                             action='append',
                             choices={'ac', 'fgl', 'fgl_b', 'humidifier'},
                             help='Device type. Deprecated, now decided based on OEM model.')
-  group_device.add_argument('--temp_type', required=True, action='append', help='Celsius or Fahrenheit')
+  group_device.add_argument('temp_type', help='Celsius or Fahrenheit')
 
   group_mqtt = parser_run.add_argument_group('MQTT', 'Settings related to the MQTT')
   group_mqtt.add_argument('--mqtt_host', default=None, help='MQTT broker hostname or IP address.')

--- a/aircon/__main__.py
+++ b/aircon/__main__.py
@@ -75,7 +75,7 @@ def ParseArguments() -> argparse.Namespace:
                             action='append',
                             choices={'ac', 'fgl', 'fgl_b', 'humidifier'},
                             help='Device type. Deprecated, now decided based on OEM model.')
-    group_device.add_argument('--temp_type', required=True, action='append', help='Celsius or Fahrenheit')
+  group_device.add_argument('--temp_type', required=True, action='append', help='Celsius or Fahrenheit')
 
   group_mqtt = parser_run.add_argument_group('MQTT', 'Settings related to the MQTT')
   group_mqtt.add_argument('--mqtt_host', default=None, help='MQTT broker hostname or IP address.')

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,6 @@ MQTT_PORT=$(jq -r '.mqtt_port // 1883' $OPTIONS_FILE)
 MQTT_USER=$(jq -r 'if (.mqtt_user and .mqtt_pass) then (.mqtt_user + ":" + .mqtt_pass) else "" end' $OPTIONS_FILE)
 APPS=$(jq -r '.app | length // 0' $OPTIONS_FILE)
 LOCAL_IP=$(jq -r 'if (.local_ip) then (.local_ip) else "" end' $OPTIONS_FILE)
-TEMP_TYPE=$(jq -r '.temp_type // "F"' $OPTIONS_FILE)
 
 mkdir -p $CONFIG_DIR
 if [ -z "$(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json")" ]; then
@@ -27,4 +26,4 @@ configs=
 for i in $(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;)
   do configs="$configs --config $CONFIG_DIR/$i --type $TYPE"
 done
-python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_port $MQTT_PORT --mqtt_user "$MQTT_USER" --temp_type "$TEMP_TYPE" --local_ip "$LOCAL_IP" $configs
+python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_port $MQTT_PORT --mqtt_user "$MQTT_USER" --local_ip "$LOCAL_IP" $configs

--- a/run.sh
+++ b/run.sh
@@ -3,12 +3,14 @@ set -e
 
 PORT=$(jq -r '.port // 8888' $OPTIONS_FILE)
 TYPE=$(jq -r '.type // "ac"' $OPTIONS_FILE)
+TYPE=$(jq -r '.type // "ac"' $OPTIONS_FILE)
 LOG_LEVEL=$(jq -r '.log_level | ascii_upcase // "WARNING"' $OPTIONS_FILE)
 MQTT_HOST=$(jq -r '.mqtt_host // ""' $OPTIONS_FILE)
 MQTT_PORT=$(jq -r '.mqtt_port // 1883' $OPTIONS_FILE)
 MQTT_USER=$(jq -r 'if (.mqtt_user and .mqtt_pass) then (.mqtt_user + ":" + .mqtt_pass) else "" end' $OPTIONS_FILE)
 APPS=$(jq -r '.app | length // 0' $OPTIONS_FILE)
 LOCAL_IP=$(jq -r 'if (.local_ip) then (.local_ip) else "" end' $OPTIONS_FILE)
+TEMP_TYPE=$(jq -r '.temp_type // "F"' $OPTIONS_FILE)
 
 mkdir -p $CONFIG_DIR
 if [ -z "$(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json")" ]; then

--- a/run.sh
+++ b/run.sh
@@ -27,4 +27,4 @@ configs=
 for i in $(find $CONFIG_DIR -maxdepth 1 -type f -name "config_*.json" -exec basename {} \;)
   do configs="$configs --config $CONFIG_DIR/$i --type $TYPE"
 done
-python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_port $MQTT_PORT --mqtt_user "$MQTT_USER" --local_ip "$LOCAL_IP" $configs
+python -m aircon --log_level $LOG_LEVEL run --port $PORT --mqtt_host "$MQTT_HOST" --mqtt_port $MQTT_PORT --mqtt_user "$MQTT_USER" --temp_type "$TEMP_TYPE" --local_ip "$LOCAL_IP" $configs


### PR DESCRIPTION
The subject pull request adds a GitHub Action that will automatically generate and publish the Docker container to the Github Container Registry every time a new release is created in GitHub.

Ex: ghcr.io/xury77/aircon:latest

This can be used as a alternative container registry on top of DockerHub, or can replace the DockerHub images entirely if that is preferable. If the latter is your preference I can also update the Docker Compose file to reflect the GHCR pathing.